### PR TITLE
Add titleBar 'frameless' option to hide window controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ When set to `wide`, activity bar will match the width of traffic lights (for mac
 
 ### `customizeUI.titleBar`
 
-macOS only. When set to `inline`, titlebar is hidden and window controls become part of sidebar. Note that this setting requires that `"window.titleBarStyle": "native"` is also set.
+macOS only. Setting this hides the titlebar, and the tab bar becomes draggable.
+
+* `inline`: places window controls in the sidebar or tab bar. 
+
+* `frameless`: hides window controls. 
+
+Note that this setting requires that `"window.titleBarStyle": "native"` is also set.
+
 
 ### `customizeUI.fontSizeMap`
 

--- a/modules/title-bar-main-process.js
+++ b/modules/title-bar-main-process.js
@@ -12,24 +12,39 @@ define([
 
     let MainProcessTitleBar = class MainProcessTitleBar {
         constructor(configurationService) {
-            if (configurationService.getValue("customizeUI.titleBar") === "inline") {
-                this.init();
+            const titleBar = configurationService.getValue("customizeUI.titleBar");
+
+            if (titleBar === "inline" || titleBar === "frameless") {
+                this.init(titleBar);
             }
         }
 
-        init() {
+        init(titleBar) {
 
             this.swizzle();
 
             class _CodeWindow extends win.CodeWindow {
                 constructor() {
-                    Object.defineProperty(Object.prototype, "titleBarStyle", {
-                        get() { return "hidden"; },
-                        set() { },
-                        configurable: true,
-                    });
-                    super(...arguments);
-                    delete Object.prototype.titleBarStyle;
+                    // https://electronjs.org/docs/api/frameless-window
+                    //
+                    if (titleBar === "frameless") {
+                        Object.defineProperty(Object.prototype, "frame", {
+                            get() { return false; },
+                            set() { },
+                            configurable: true,
+                        });
+                        super(...arguments);
+                        delete Object.prototype.frame;
+
+                    } else {
+                        Object.defineProperty(Object.prototype, "titleBarStyle", {
+                            get() { return "hidden"; },
+                            set() { },
+                            configurable: true,
+                        });
+                        super(...arguments);
+                        delete Object.prototype.titleBarStyle;
+                    }
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
 					"description": "Inline title bar style for macOS",
 					"enum": [
 						"regular",
-						"inline"
+						"inline",
+            "frameless"
 					]
 				},
 				"customizeUI.stylesheet": {


### PR DESCRIPTION
The window controls are unnecessary for those who use shortcuts and window managers.