### PR TITLE
Fix selector for changed action icon size

### DIFF
--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -358,7 +358,8 @@ body.inline-title-bar .monaco-workbench:not(.fullscreen) .sidebar .composite.tit
 body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container,
 body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .tabs-container>.tab,
 body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .editor-actions,
-body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .editor-actions .action-label, .monaco-workbench .part.editor>.content .editor-group-container>.title .title-actions .action-label {
+body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .editor-actions .action-label,
+body.inline-title-bar .monaco-workbench .part.editor>.content .editor-group-container>.title .title-actions .action-label {
     height: var(--traffic-lights-height) !important;
     line-height: var(--traffic-lights-height) !important;
 }


### PR DESCRIPTION
This should avoid that the smaller icons are also used when the inline title bar is not in use as described in #42 