### PR TITLE
fix vertical alignment of icons in explorer with custom `listRowHeight`

### DIFF
--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -156,6 +156,7 @@
 }
 
 .explorer-viewlet .explorer-item,
+.explorer-viewlet .explorer-item::before,
 .explorer-viewlet .open-editor,
 .explorer-viewlet .editor-group {
     height: var(--row-height) !important;


### PR DESCRIPTION
Fixes #67.

Please test it out with a config like this before merging:

```json
  "customizeUI.listRowHeight": 34,
```

cc @nrthbound