### PR TITLE
Add object type support

### DIFF
--- a/modules/fonts.js
+++ b/modules/fonts.js
@@ -47,7 +47,12 @@ define([
         }
 
         addCustomStyleSheet(styleSheet) {
-            let string = Object.entries(styleSheet).map(([key, value]) => `${key} { ${value}; }`).join("\n");
+            let string = Object.entries(styleSheet).map(([key, value]) => {
+                if (typeof value === 'object') {
+                    value = Object.entries(value).map(([key, value]) => `${key}: ${value};`).join("\n")
+                }
+                return `${key} { ${value}; }`
+            }).join("\n");
             addStyle(string);
         }
 


### PR DESCRIPTION
I think it would be great if the extension has stylesheet custom object support instead of string only. This can allow user to pass object or string on `customizeUI.stylesheet` data