### PR TITLE
Add activitybar top position & no move statusbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,18 @@ This experimental extension allows customizing VSCode user interface beyond what
 
 ### `customizeUI.activityBar`
 
+When set to `top`, activity bar will be positioned over the sidebar.
+
 When set to `bottom`, activity bar will be positioned below the sidebar.
 
 When set to `wide`, activity bar will match the width of traffic lights (for macOS inline menu bar).
+
+### `customizeUI.moveStatusbar`
+
+When enabled move the statusbar below the panel (Terminal, Output, Problems). Useful to gain some space for the sidebar.
+
+**WARNING:** don't works well if panel is set to left or right,  
+this setting was added to be able to disable the default behavior.
 
 ### `customizeUI.activityBarHideSettings`
 

--- a/package.json
+++ b/package.json
@@ -50,9 +50,14 @@
 					"description": "Position activity bar below the sidebar or make match traffic lights dimensions (for inline title bar)",
 					"enum": [
 						"regular",
+						"top",
 						"bottom",
 						"wide"
 					]
+				},
+				"customizeUI.moveStatusbar": {
+					"type": "boolean",
+					"description": "Move statusbar under panel."
 				},
 				"customizeUI.activityBarHideSettings": {
 					"type": "boolean",
@@ -148,7 +153,7 @@
 	"extensionDependencies": [
 		"iocave.monkey-patch"
 	],
-	"extensionKind": "ui",
+	"extensionKind": ["ui"],
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",


### PR DESCRIPTION
- Add `top` to `customizeUI.activityBar` to be able to have the activity bar on top of the sidebar.
- Add `customizeUI.moveStatusbar` to prevent modification on the statusbar.