### PR TITLE
Fix collapsed horizontal panes display

### DIFF
--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -148,6 +148,9 @@
 .monaco-pane-view .pane > .pane-header {
     height: var(--row-height) !important;
 }
+.monaco-pane-view .pane.horizontal:not(.expanded) > .pane-header {
+    height: 100% !important;
+}
 
 /* TODO: actions should be part of the pane, but they aren't yet */
 .monaco-pane-view .pane > .pane-header > .actions .action-label.icon,


### PR DESCRIPTION
I finally noticed, before i applied the monkey patch, that there's icons that display on collapsed horizontal views. (introduced in [v1.46.0 May 2020](https://code.visualstudio.com/updates/v1_46#_flexible-layout) / https://github.com/microsoft/vscode/commit/38258f6217771e35f7f8f962dae46f27aa1a411a ) but the `!important` was hiding it. This change copies the style rule with another `!important` to fix it.