### PR TITLE
Fix the attribute name for description of some properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,15 +78,15 @@
 				},
 				"customizeUI.listRowHeight": {
 					"type": "integer",
-					"title": "Height of rows in lists and trees in pixels (defaults to 22)"
+					"description": "Height of rows in lists and trees in pixels (defaults to 22)"
 				},
 				"customizeUI.font.regular": {
 					"type": "string",
-					"title": "Replacement font family for regular UI font"
+					"description": "Replacement font family for regular UI font"
 				},
 				"customizeUI.font.monospace": {
 					"type": "string",
-					"title": "Replacement font family for monospace UI font"
+					"description": "Replacement font family for monospace UI font"
 				},
 				"customizeUI.fontSizeMap": {
 					"default": {


### PR DESCRIPTION
_As a thank you for this great extension, I wish to give a small and humble fix._

The JSON attribute name was "title" for these properties. It caused the description to never appear in VSCode.
* listRowHeight
* font.regular
* font.monospace

![image](https://user-images.githubusercontent.com/6047296/128945355-31525b80-a94b-4f0f-8e3a-0d783bc5b306.png)
![image](https://user-images.githubusercontent.com/6047296/128945401-c71f70c5-5b31-4e58-b78f-ab7fcee48b3e.png)
