### PR TITLE
Fix title bar height

### DIFF
--- a/modules/activity-bar.js
+++ b/modules/activity-bar.js
@@ -25,7 +25,7 @@ define([
         let trafficLightDimensions = function () {
             let size = {
                 width: 77,
-                height: 37,
+                height: 38,
             }
             return {
                 width: size.width / browser.getZoomFactor(),

--- a/modules/title-bar.js
+++ b/modules/title-bar.js
@@ -66,7 +66,7 @@ define([
             trafficLightDimensions() {
                 let size = {
                     width: 77,
-                    height: 37,
+                    height: 38,
                 }
                 return {
                     width: size.width / browser.getZoomFactor(),


### PR DESCRIPTION
I measured with a screen-measuring tool, and it appears that the spacing above the traffic lights is currently 1px larger than the spacing below them. This PR fixes that.