### PR TITLE
Fix UI font families to accept multiple fonts

### DIFF
--- a/modules/fonts.js
+++ b/modules/fonts.js
@@ -36,11 +36,17 @@ define([
 
             let fontFamily = this.configurationService.getValue("customizeUI.font.regular");
             if (typeof (fontFamily) == "string" && fontFamily.length > 0) {
+                if (fontFamily.indexOf(",") == -1) {
+                    fontFamily = `"${fontFamily}"`
+                }
                 this.setFontFamily(fontFamily);
             }
 
             let monospaceFamily = this.configurationService.getValue("customizeUI.font.monospace");
             if (typeof (monospaceFamily) == "string" && monospaceFamily.length > 0) {
+                if (monospaceFamily.indexOf(",") == -1) {
+                    monospaceFamily = `"${monospaceFamily}"`
+                }
                 this.setMonospaceFontFamily(monospaceFamily);
             }
         }
@@ -56,11 +62,11 @@ define([
         }
 
         setFontFamily(fontFamily) {
-            addStyle(`.mac, .windows, .linux { font-family: "${fontFamily}" !important; }`);
+            addStyle(`.mac, .windows, .linux { font-family: ${fontFamily} !important; }`);
         }
 
         setMonospaceFontFamily(fontFamily) {
-            addStyle(`.mac, .windows, .linux { --monaco-monospace-font:"${fontFamily}" !important; }`);
+            addStyle(`.mac, .windows, .linux { --monaco-monospace-font: ${fontFamily} !important; }`);
         }
 
         updateFontSize(fontSizeMap) {


### PR DESCRIPTION
#30 found a bug and the underlying problem, but there had been no PR to fix this so I made one.

This PR makes UI font family config options to accept multiple fonts, by fixing the logic to wrap the value with `""` *only when* it does not have a `,` (which implies the family of multiple fonts).