### PR TITLE
Fix vertically misaligned various sidebar elements

### DIFF
--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -155,8 +155,11 @@
     height: var(--row-height) !important;
 }
 
+.monaco-icon-label::before {
+    height: auto !important;
+}
+
 .explorer-viewlet .explorer-item,
-.explorer-viewlet .explorer-item::before,
 .explorer-viewlet .open-editor,
 .explorer-viewlet .editor-group {
     height: var(--row-height) !important;

--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -103,13 +103,17 @@
     font-size: var(--font-size-menu) !important;
 }
 
-.monaco-workbench .debug-viewlet .monaco-list-row .expression,
-.monaco-workbench .debug-hover-widget .monaco-list-row .expression,
-.monaco-workbench .debug-viewlet .monaco-list-row .expression,
-.monaco-workbench .debug-hover-widget .monaco-list-row .expression,
-.monaco-workbench.mac .debug-viewlet .monaco-list-row .expression,
-.monaco-workbench.mac .debug-hover-widget .monaco-list-row .expression {
+.debug-viewlet .debug-watch .monaco-list-row .expression,
+.debug-hover-widget .monaco-list-row .expression {
     font-size: var(--font-size-monospace) !important;
+}
+
+.debug-viewlet .debug-watch .monaco-list-row .expression,
+.debug-viewlet .debug-call-stack .monaco-list-row .session,
+.debug-viewlet .debug-call-stack .monaco-list-row .stack-frame,
+.debug-viewlet .debug-breakpoints .monaco-list-row .breakpoint {
+    /* Prevent texts from exceeding row height and making something misaligned */
+    height: var(--row-height) !important;
 }
 
 .customview-tree .monaco-tree .monaco-tree-row .custom-view-tree-node-item > .custom-view-tree-node-item-icon {
@@ -157,6 +161,10 @@
 
 .monaco-icon-label::before {
     height: auto !important;
+}
+
+.debug-viewlet .debug-call-stack .codicon-callstack-view-session::before {
+    vertical-align: middle;
 }
 
 .explorer-viewlet .explorer-item,

--- a/modules/customize-ui.css
+++ b/modules/customize-ui.css
@@ -116,6 +116,15 @@
     height: var(--row-height) !important;
 }
 
+/* Number badges */
+/* These would be simpler with :has() selector, but it requires Chromium 105 (Electron v21) */
+.search-view .results .filematch .badge,
+.debug-viewlet .debug-call-stack .line-number-wrapper,
+.debug-viewlet .debug-breakpoints .line-number-container {
+    display: flex;
+    align-items: center;
+}
+
 .customview-tree .monaco-tree .monaco-tree-row .custom-view-tree-node-item > .custom-view-tree-node-item-icon {
     height: var(--row-height) !important;
 }


### PR DESCRIPTION
This PR fixes most of misaligned sidebar elements, such as:

- File icons on 'Open Editors' pane and 'Source Control' tab
- Flicking texts and icons on 'Breakpoints' pane when hovering
- Misaligned hover buttons and icons on 'Debug' tab
- Misaligned number badges on 'Search' and 'Debug' tab